### PR TITLE
Hide URLs in course People list CAN-27

### DIFF
--- a/sass/_people.scss
+++ b/sass/_people.scss
@@ -8,7 +8,7 @@ body.people [id^="user-avatar-people-page"] span {
 
 @media print {
     // When printing hide HUIDS and URLs
-    a[href]:after,
+    body.people a[href]:after,
     body.people .roster td:nth-child(3), 
     body.people .roster th:nth-child(3), 
     body.people .roster td:nth-child(4), 

--- a/sass/_people.scss
+++ b/sass/_people.scss
@@ -7,7 +7,8 @@ body.people [id^="user-avatar-people-page"] span {
 }
 
 @media print {
-    // When printing hide HUIDS
+    // When printing hide HUIDS and URLs
+    a[href]:after,
     body.people .roster td:nth-child(3), 
     body.people .roster th:nth-child(3), 
     body.people .roster td:nth-child(4), 


### PR DESCRIPTION
Description
----------------
We want to hide the URLs that show when printing:
![image](https://user-images.githubusercontent.com/10763433/129796436-7ed36331-950d-496d-baf5-d7e416b1cde0.png)

This is in test:
![image](https://user-images.githubusercontent.com/10763433/129796490-99dd4353-3ae2-4deb-b020-ea5de8533a3d.png)

https://harvard.test.instructure.com/courses/31965/users/241131

Requirements
------------
<!--List anything needed to test that is not part of the standard HSPH local development environment-->

**Branches:**
<!--List any required branches in this format: repository-name/branch-name-->

1. this

Test Steps
----------
<!--Be explicit. Use screenshots if necessary. Don't assume the reviewer knows what you know-->

1. When comparing production, e.g. https://harvard.instructure.com/courses/54302/users, you see the URLs showing as above, when you print from the browser (ctrl/command + p)
2. When you look in test, you see they are gone.

Web Accessibility 
----------------
<!--All changes introduced in this PR meet our web accessibility guidelines -->

- [ ] All changes in this PR conform with the current version of our [Web Accessibility PR Checklist](https://wiki.harvard.edu/confluence/pages/viewpage.action?spaceKey=HSPHWeb&title=Web+Accessibility+PR+Checklist).


Related
-----------------
**Jira Issues**

<!--List issue numbers here. Ex: ABC-1234-->

1. this (CAN-27)
2. This is a follow-up request to what Guillaume did before leave: CAN-22, CAN-24, CAN-25


<!--**Wiki articles**-->

  <!--Link to any related Wiki articles-->

https://wiki.harvard.edu/confluence/display/HSPHWeb/Canvas+and+Canvas+Catalog

